### PR TITLE
Allow Broker Update through Config message

### DIFF
--- a/RaprotoService/inc/settings.h
+++ b/RaprotoService/inc/settings.h
@@ -128,13 +128,13 @@
 #define RAPROTO_SETTING_LOGGING								"SERVICE_LOGGING"
 #define RAPROTO_SETTING_ERROR								"SERVICE_ERROR"
 
-#ifdef RELEASE_NEURALERT
-	#define RAPROTO_SETTING_MQTT_BROKER_DEFAULT					"ssl://thingsboard.neuralerttechnologies.com:8883"
-	#define RAPROTO_SETTING_NAME_DEFAULT							"Neuralert"
-#else
+//#ifdef RELEASE_NEURALERT
+//	#define RAPROTO_SETTING_MQTT_BROKER_DEFAULT					"ssl://thingsboard.neuralerttechnologies.com:1883"
+//	#define RAPROTO_SETTING_NAME_DEFAULT							"Neuralert"
+//#else
 	#define RAPROTO_SETTING_MQTT_BROKER_DEFAULT					"ssl://tb.precise.seas.upenn.edu:8883"
 	#define RAPROTO_SETTING_NAME_DEFAULT							"\0"
-#endif
+//#endif
 
 #define RAPROTO_SETTING_SENSOR_ACC			"ACC"
 #define RAPROTO_SETTING_SENSOR_HRM			"HRM"

--- a/RaprotoService/src/config.c
+++ b/RaprotoService/src/config.c
@@ -96,6 +96,7 @@ config_get_settings_from_json(bundle *settings, char *s){
 		//dlog_print(DLOG_INFO, LOG_TAG, "token %d: %d, %d, %d, %d",n, t[n].type, t[n].start, t[n].end, t[n].size);
 
 		if ((rc = config_is_valid_setting(RAPROTO_SETTING_NAME, JSMN_STRING, &t[n], s)) == RAPROTO_ERROR_NONE) config_get_setting_for_key(settings, &t[n], s);
+		else if ((rc = config_is_valid_setting(RAPROTO_SETTING_MQTT_BROKER, JSMN_STRING, &t[n], s)) == RAPROTO_ERROR_NONE) config_get_setting_for_key(settings, &t[n], s);
 		else if ((rc = config_is_valid_setting(RAPROTO_SETTING_MQTT_PUB_TOPIC, JSMN_STRING, &t[n], s)) == RAPROTO_ERROR_NONE) config_get_setting_for_key(settings, &t[n], s);
 		else if ((rc = config_is_valid_setting(RAPROTO_SETTING_MQTT_QOS, JSMN_PRIMITIVE, &t[n], s)) == RAPROTO_ERROR_NONE) config_get_setting_for_key(settings, &t[n], s);
 		else if ((rc = config_is_valid_setting(RAPROTO_SETTING_MQTT_KEEP_ALIVE, JSMN_PRIMITIVE, &t[n], s)) == RAPROTO_ERROR_NONE) config_get_setting_for_key(settings, &t[n], s);

--- a/RaprotoService/src/settings.c
+++ b/RaprotoService/src/settings.c
@@ -79,10 +79,11 @@ settings_init(){
 	bundle_add_str(settings, RAPROTO_SETTING_MQTT_CLIENT_ID, RAPROTO_SETTING_MQTT_CLIENT_ID_DEFAULT);
 
 	char str[1000];
-	sprintf(str,"{\"sharedKeys\":\"%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\"}",
+	sprintf(str,"{\"sharedKeys\":\"%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\"}",
 		RAPROTO_SETTING_NAME,
 		RAPROTO_SETTING_POWER,
 		RAPROTO_SETTING_WIFI,
+		RAPROTO_SETTING_MQTT_BROKER,
 		RAPROTO_SETTING_WIFI_TIMEOUT,
 		RAPROTO_SETTING_MQTT_PUB_TOPIC,
 		RAPROTO_SETTING_MQTT_QOS,


### PR DESCRIPTION
This functionality will allow for configuration with other MQTT brokers by using the thingsboard interface.  We will leave the ability to do manual edits on the watch, but this simplifies the setup during development/updates.